### PR TITLE
Center vertical name pills and preserve width

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,6 +59,7 @@ function generateName(region) {
 
 function generateNames() {
   container.innerHTML = '';
+  const pills = [];
   for (let i = 0; i < NUM_PILLS; i++) {
     const name = generateName(regionSelect.value);
     const pill = document.createElement('div');
@@ -67,14 +68,19 @@ function generateNames() {
     pill.dataset.name = name;
     pill.addEventListener('click', () => handleCopy(pill));
     container.appendChild(pill);
+    pills.push(pill);
   }
+  const maxWidth = Math.max(...pills.map(p => p.offsetWidth));
+  pills.forEach(p => {
+    p.style.width = `${maxWidth}px`;
+  });
 }
 
 function handleCopy(pill) {
   if (pill.classList.contains('copied')) return;
   const name = pill.dataset.name;
   navigator.clipboard.writeText(name).then(() => {
-    pill.textContent = 'Copied name';
+    pill.textContent = '✓ Copied name';
     setTimeout(() => {
       pill.textContent = name;
       pill.classList.add('copied');

--- a/styles.css
+++ b/styles.css
@@ -9,20 +9,23 @@ body {
 
 #name-container {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   gap: 10px;
 }
 
 .pill {
   padding: 10px 15px;
   border-radius: 20px;
-  background: #e0f7fa;
+  background: #ffffff;
+  border: 1px solid #cccccc;
   cursor: pointer;
   user-select: none;
+  text-align: center;
 }
 
 .pill.copied {
-  background: #cccccc;
+  background: #f0f0f0;
   color: #666666;
   cursor: default;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Stack generated name pills vertically and center them.
- Ensure pills keep a consistent width and show a checkmark when copied.
- Refresh pill styling to match design.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab410aaf408326b362829ec4cee780