### PR TITLE
Sanitize names and allow recopy

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,14 +4,27 @@ const refreshBtn = document.getElementById('refresh');
 const container = document.getElementById('name-container');
 const NUM_PILLS = 9;
 
+sanitizeNameData(nameData);
+
+function sanitizeNameData(data) {
+  const regex = /^[A-Za-z]+$/;
+  Object.values(data).forEach(region => {
+    ['first', 'last'].forEach(list => {
+      region[list] = region[list]
+        .filter(name => regex.test(name))
+        .map(name => name.toUpperCase());
+    });
+  });
+}
+
 function randomFrom(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
 function generateName(region) {
   const data = nameData[region];
-  const first = randomFrom(data.first);
-  const last = randomFrom(data.last);
+  const first = randomFrom(data.first).toUpperCase();
+  const last = randomFrom(data.last).toUpperCase();
   return `-${last}/${first}`;
 }
 
@@ -37,7 +50,6 @@ function generateNames() {
 }
 
 function handleCopy(pill) {
-  if (pill.classList.contains('copied')) return;
   const name = pill.dataset.name;
   navigator.clipboard.writeText(name).then(() => {
     pill.textContent = '✓ Copied name';

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,4 @@ h1 {
 .pill.copied {
   background: rgba(240, 240, 240, 0.9);
   color: #666666;
-  cursor: default;
-  pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- sanitize regional name data to uppercase A-Z entries only
- allow copied names to be clicked and copied again while keeping the greyed-out style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5b23167c83269bf2fe3d98923da5