### PR TITLE
Center name pills and refine copy feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,7 +56,7 @@ function handleCopy(pill) {
     setTimeout(() => {
       pill.textContent = name;
       pill.classList.add('copied');
-    }, 1000);
+    }, 700);
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,7 @@
   box-shadow:var(--shadow-card);
   color:var(--ink);
   padding:var(--space-4);
+  padding-bottom:var(--space-5);
 }
 .btn-primary{
   background:var(--action); color:#fff;
@@ -113,10 +114,14 @@ h1{
   user-select:none;
   transition:box-shadow .15s ease-out, transform .15s ease-out;
   white-space:nowrap;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
 }
 
 .pill:hover{
-  box-shadow:0 2px 2px rgba(17,24,39,.08), 0 6px 16px rgba(17,24,39,.12);
+  box-shadow:0 0 0 2px rgba(59,130,246,.5), 0 2px 2px rgba(17,24,39,.08), 0 6px 16px rgba(17,24,39,.12);
   transform:translateY(-1px);
 }
 
@@ -128,7 +133,8 @@ h1{
 .pill:focus{outline:none; box-shadow:var(--ring-focus);}
 
 .pill.copied{
-  background:var(--accent);
-  color:#fff;
+  background:var(--line);
+  color:var(--muted);
+  border-color:var(--line);
 }
 


### PR DESCRIPTION
## Summary
- Center name pills with flex layout and show a blue glow on hover
- Gray out copied names and reduce copy confirmation timeout
- Add extra padding to card bottom for breathing room

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab638c28508326a907688f3cb7e382