### PR TITLE
feat: add automatic dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
   <title>Random Name Generator</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@
   --canvas:#F2F4F7; --card:#FFF;
   --ink:#111827; --muted:#6B7280; --line:#E5E7EB;
   --accent:#16A34A; --brand:#FF7A00; --action:#111827;
+  --btn-border:rgba(17,24,39,.12); --segment:#F3F4F6; --bar:#E5E7EB;
 
   --r-xxl:32px; --r-xl:20px; --r-lg:14px; --r-md:12px; --r-pill:9999px;
   --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px;
@@ -9,6 +10,15 @@
   --shadow-card: 0 1px 2px rgba(17,24,39,.06), 0 8px 20px rgba(17,24,39,.08);
   --shadow-float:0 1px 1px rgba(17,24,39,.08), 0 4px 10px rgba(17,24,39,.10);
   --ring-focus:0 0 0 2px rgba(22,163,74,.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root{
+    --canvas:#0F172A; --card:#1E293B;
+    --ink:#F8FAFC; --muted:#9CA3AF; --line:#334155;
+    --accent:#16A34A; --brand:#FF7A00; --action:#2563EB;
+    --btn-border:rgba(255,255,255,.12); --segment:#273244; --bar:#334155;
+  }
 }
 .canvas{background:var(--canvas);}
 .card{
@@ -23,21 +33,21 @@
 .btn-primary{
   background:var(--action); color:#fff;
   border-radius:var(--r-lg); padding:10px 14px;
-  border:1px solid rgba(17,24,39,.12);
+  border:1px solid var(--btn-border);
 }
 .btn-primary:focus{outline:none; box-shadow:var(--ring-focus);}
 .segment{
-  background:#F3F4F6; border:1px solid var(--line);
+  background:var(--segment); border:1px solid var(--line);
   border-radius:var(--r-pill); padding:4px;
 }
 .segment .item{
   border-radius:var(--r-md); padding:6px 10px; color:var(--muted);
 }
 .segment .item.active{
-  background:#FFF; color:var(--ink);
+  background:var(--card); color:var(--ink);
   border:1px solid var(--line); box-shadow:var(--shadow-float);
 }
-.bar{ background:#E5E7EB; border-radius:6px; }
+.bar{ background:var(--bar); border-radius:6px; }
 .bar--active{ background:var(--accent); }
 .delta--up{ color:var(--accent); font-weight:600; }
 


### PR DESCRIPTION
## Summary
- detect user's preferred color scheme and apply matching theme
- define dark theme palette with CSS variables
- add `color-scheme` meta tag for native form styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66890cdc83269ed13386a9b8fd81