### PR TITLE
Delay initial name generation until fonts are ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,5 +62,9 @@ function handleCopy(pill) {
 
 refreshBtn.addEventListener('click', generateNames);
 regionSelect.addEventListener('change', generateNames);
-
-generateNames();
+// Wait for fonts to load so the pill dimensions are accurate on first render
+if (document.fonts && document.fonts.ready) {
+  document.fonts.ready.then(generateNames);
+} else {
+  window.addEventListener('load', generateNames);
+}


### PR DESCRIPTION
## Summary
- Wait for font loading before rendering initial pill list
- Fall back to window load event when Font Loading API is unavailable

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab685573d0832681aeeb4defec8dcb