### PR TITLE
Allow non-Latin characters in generated names

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,8 @@ const NUM_PILLS = 9;
 sanitizeNameData(nameData);
 
 function sanitizeNameData(data) {
-  const regex = /^[A-Za-z]+$/;
+  // Allow letters from any language plus common name punctuation
+  const regex = /^[\p{L}' -]+$/u;
   Object.values(data).forEach(region => {
     ['first', 'last'].forEach(list => {
       region[list] = region[list]


### PR DESCRIPTION
## Summary
- expand name sanitization to accept Unicode letters and common punctuation

## Testing
- `npm test` *(fails: no such file or directory)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68ab691ae8d88326865e3a44bef81ed4