### PR TITLE
Ensure generated names use English letters only

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,12 +7,13 @@ const NUM_PILLS = 9;
 sanitizeNameData(nameData);
 
 function sanitizeNameData(data) {
-  // Allow letters from any language plus common name punctuation
-  const regex = /^[\p{L}' -]+$/u;
+  // Remove diacritics and restrict to English letters with common punctuation
+  const ascii = /^[A-Z' -]+$/;
   Object.values(data).forEach(region => {
     ['first', 'last'].forEach(list => {
       region[list] = region[list]
-        .filter(name => regex.test(name))
+        .map(name => name.normalize('NFD').replace(/[\u0300-\u036f]/g, ''))
+        .filter(name => ascii.test(name))
         .map(name => name.toUpperCase());
     });
   });


### PR DESCRIPTION
## Summary
- normalize and filter loaded name data so only English alphabet letters remain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6c3a9cb48326b23a421a01f911cb