### PR TITLE
Sanitize last names

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,19 +7,28 @@ const NUM_PILLS = 9;
 sanitizeNameData(nameData);
 
 function sanitizeNameData(data) {
-  // Remove diacritics and restrict to English letters with common punctuation
+  // Remove diacritics and restrict to English letters.
   const ascii = /^[A-Z' -]+$/;
   Object.values(data).forEach(region => {
-    ['first', 'last'].forEach(list => {
-      region[list] = region[list]
-        .map(name =>
-          name
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .toUpperCase()
-        )
-        .filter(name => ascii.test(name));
-    });
+    // Sanitize first names
+    region.first = region.first
+      .map(name =>
+        name
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .toUpperCase()
+      )
+      .filter(name => ascii.test(name));
+    // Sanitize last names and strip spaces and punctuation
+    region.last = region.last
+      .map(name =>
+        name
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .replace(/[-'` ]/g, '')
+          .toUpperCase()
+      )
+      .filter(name => /^[A-Z]+$/.test(name));
   });
 }
 


### PR DESCRIPTION
## Summary
- Strip spaces, hyphens, backticks and apostrophes from last names
- Keep first name sanitization but tighten last name filtering to letters only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab712a38fc8326952434b99d2d9b15