### PR TITLE
shorten copied name message

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,7 @@ function generateNames() {
 function handleCopy(pill) {
   const name = pill.dataset.name;
   navigator.clipboard.writeText(name).then(() => {
-    pill.textContent = '✓ Copied name';
+    pill.textContent = '✓ Copied';
     setTimeout(() => {
       pill.textContent = name;
       pill.classList.add('copied');


### PR DESCRIPTION
## Summary
- shorten copied name confirmation text to just "✓ Copied"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab72ae9228832693dbed30ef2479b1