### PR TITLE
feat: add glass neumorphic theme

### DIFF
--- a/glass.css
+++ b/glass.css
@@ -1,0 +1,66 @@
+:root{
+  --indigo-light:#5F60C8; --paper:#FFFFFF;
+  --indigo-dark:#1E1A48; --near-black:#0B0A12;
+  --glass-1:#7A59C9; --glass-2:#6442AF;
+  --icon-dark:#22173C; --icon-light:#D9D6EE;
+
+  --r-pill:9999px;
+  --shadow-light:0 12px 28px rgba(38,20,70,.22),0 2px 4px rgba(0,0,0,.06);
+  --shadow-dark:0 14px 32px rgba(0,0,0,.45),0 2px 4px rgba(0,0,0,.28);
+  --stroke-hi:rgba(255,255,255,.42);
+  --stroke-lo:rgba(0,0,0,.16);
+}
+
+/* background */
+.body--light{ background: linear-gradient(135deg,var(--indigo-light),var(--paper)); }
+.body--dark { background: linear-gradient(135deg,var(--indigo-dark),var(--near-black)); }
+.body--light, .body--dark{ position:relative; min-height:100vh; }
+.body--light::before,
+.body--dark::before{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:-1;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size:200px 200px; opacity:.07;
+}
+.body--dark::before{ opacity:.05; }
+.body--light::after,
+.body--dark::after{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:-1;
+  background:radial-gradient(circle at center,rgba(0,0,0,0) 60%,rgba(0,0,0,.25) 100%);
+}
+
+/* glass track */
+.toggle{
+  position:relative;
+  display:flex; align-items:center;
+  height:60px; padding:8px;
+  background: linear-gradient(160deg,var(--glass-1),var(--glass-2));
+  border-radius: var(--r-pill);
+  border:1.5px solid var(--stroke-hi);
+  outline:1px solid var(--stroke-lo);
+  box-shadow: var(--shadow-light);
+  backdrop-filter: blur(10px);
+  margin:40px auto;
+}
+.body--dark .toggle{ box-shadow: var(--shadow-dark); }
+.toggle .icon{
+  flex:1; display:flex; justify-content:center; align-items:center;
+  cursor:pointer; background:none; border:none; padding:0;
+  transition:transform .15s ease;
+}
+.toggle .icon:hover{ transform:translateY(-1px); }
+.toggle .icon svg{
+  width:24px; height:24px;
+  stroke:var(--icon-dark);
+  stroke-width:2.2; stroke-linecap:round; stroke-linejoin:round;
+  fill:none;
+}
+.body--dark .toggle .icon svg{ stroke:var(--icon-light); }
+.toggle .thumb{
+  position:absolute; top:8px; left:8px;
+  width:44px; height:44px; border-radius:50%;
+  background: linear-gradient(145deg,#8B6BDD,#6C49C2);
+  box-shadow: inset 0 2px 6px rgba(0,0,0,.25), 0 6px 12px rgba(0,0,0,.18);
+  border:1px solid rgba(255,255,255,.4);
+  transition:transform .25s ease;
+  pointer-events:none;
+}

--- a/index.html
+++ b/index.html
@@ -8,8 +8,37 @@
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="glass.css">
 </head>
-<body class="canvas">
+<body class="body--light">
+  <div class="toggle" id="theme-toggle" role="group" aria-label="Theme">
+    <div class="thumb"></div>
+    <button class="icon active" data-theme="light" aria-label="Light theme">
+      <svg viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="5"/>
+        <line x1="12" y1="1" x2="12" y2="3"/>
+        <line x1="12" y1="21" x2="12" y2="23"/>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+        <line x1="1" y1="12" x2="3" y2="12"/>
+        <line x1="21" y1="12" x2="23" y2="12"/>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      </svg>
+    </button>
+    <button class="icon" data-theme="auto" aria-label="System theme">
+      <svg viewBox="0 0 24 24">
+        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+        <line x1="8" y1="21" x2="16" y2="21"/>
+        <line x1="12" y1="17" x2="12" y2="21"/>
+      </svg>
+    </button>
+    <button class="icon" data-theme="dark" aria-label="Dark theme">
+      <svg viewBox="0 0 24 24">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79"/>
+      </svg>
+    </button>
+  </div>
   <div class="card">
     <h1>Random Name Generator</h1>
     <div class="controls">

--- a/script.js
+++ b/script.js
@@ -83,3 +83,48 @@ if (document.fonts && document.fonts.ready) {
 } else {
   window.addEventListener('load', generateNames);
 }
+
+// theme toggle
+const themeToggle = document.getElementById('theme-toggle');
+if (themeToggle) {
+  const thumb = themeToggle.querySelector('.thumb');
+  const buttons = themeToggle.querySelectorAll('.icon');
+
+  function applyTheme(theme) {
+    const root = document.documentElement;
+    const body = document.body;
+    root.removeAttribute('data-theme');
+    body.classList.remove('body--light', 'body--dark');
+    if (theme === 'light') {
+      root.setAttribute('data-theme', 'light');
+      body.classList.add('body--light');
+    } else if (theme === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+      body.classList.add('body--dark');
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+      body.classList.add(prefersDark ? 'body--dark' : 'body--light');
+    }
+  }
+
+  function moveThumb(index) {
+    const segment = themeToggle.offsetWidth / buttons.length;
+    thumb.style.transform = `translateX(${segment * index}px)`;
+  }
+
+  buttons.forEach((btn, index) => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      moveThumb(index);
+      applyTheme(btn.dataset.theme);
+    });
+  });
+
+  window.addEventListener('load', () => {
+    const activeIndex = Array.from(buttons).findIndex(b => b.classList.contains('active'));
+    moveThumb(activeIndex);
+    applyTheme(buttons[activeIndex].dataset.theme);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -148,3 +148,18 @@ h1{
   border-color:var(--line);
 }
 
+/* theme overrides */
+:root[data-theme='light']{
+  --canvas:#F2F4F7; --card:#FFF;
+  --ink:#111827; --muted:#6B7280; --line:#E5E7EB;
+  --accent:#16A34A; --brand:#FF7A00; --action:#111827;
+  --btn-border:rgba(17,24,39,.12); --segment:#F3F4F6; --bar:#E5E7EB;
+}
+
+:root[data-theme='dark']{
+  --canvas:#0F172A; --card:#1E293B;
+  --ink:#F8FAFC; --muted:#9CA3AF; --line:#334155;
+  --accent:#16A34A; --brand:#FF7A00; --action:#2563EB;
+  --btn-border:rgba(255,255,255,.12); --segment:#273244; --bar:#334155;
+}
+


### PR DESCRIPTION
## Summary
- introduce glass-neumorphic theme variables and background with grain and vignette
- add segmented toggle control for choosing light, system, or dark theme
- wire up theme toggle to switch gradients and color tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab77e045348326a1c655fda76c5e12