### PR TITLE
feat: add theme support and solid styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="color-scheme" content="dark">
+  <meta name="color-scheme" content="light dark">
   <title>Random Name Generator</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,27 @@
 :root{
-  --card:rgba(255,255,255,0.1);
-  --ink:#ffffff; --muted:rgba(255,255,255,0.7); --line:rgba(255,255,255,0.2);
+  --card:#ffffff;
+  --ink:#000000; --muted:#555555; --line:rgba(0,0,0,0.15);
   --accent:#16A34A; --brand:#FF7A00; --action:#7C3AED;
-  --btn-border:rgba(255,255,255,0.2); --segment:rgba(255,255,255,0.1); --bar:rgba(255,255,255,0.1);
+  --btn-border:rgba(0,0,0,0.1); --segment:#f5f5f5; --bar:#e0e0e0;
 
   --r-xxl:32px; --r-xl:20px; --r-lg:14px; --r-md:12px; --r-pill:9999px;
   --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px;
 
-  --shadow-card:0 1px 2px rgba(0,0,0,.25),0 8px 20px rgba(0,0,0,.3);
-  --shadow-float:0 1px 1px rgba(0,0,0,.2),0 4px 10px rgba(0,0,0,.3);
+  --shadow-card:0 1px 2px rgba(0,0,0,.08),0 8px 20px rgba(0,0,0,.08);
+  --shadow-float:0 1px 1px rgba(0,0,0,.08),0 4px 10px rgba(0,0,0,.1);
   --ring-focus:0 0 0 2px rgba(124,58,237,.35);
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --card:#2d2d35;
+    --ink:#ffffff; --muted:rgba(255,255,255,0.7); --line:rgba(255,255,255,0.2);
+    --btn-border:rgba(255,255,255,0.2); --segment:#34343d; --bar:#34343d;
+
+    --shadow-card:0 1px 2px rgba(0,0,0,.25),0 8px 20px rgba(0,0,0,.3);
+    --shadow-float:0 1px 1px rgba(0,0,0,.2),0 4px 10px rgba(0,0,0,.3);
+  }
+  body{background:linear-gradient(135deg,#2a2348,#1a162c);}
 }
 .card{
   background:var(--card);
@@ -19,7 +31,6 @@
   color:var(--ink);
   padding:var(--space-4);
   padding-bottom:var(--space-5);
-  backdrop-filter:blur(10px);
 }
 .btn-primary{
   background:var(--action); color:#fff;
@@ -50,7 +61,7 @@ body{
   align-items:center;
   min-height:100vh;
   color:var(--ink);
-  background:linear-gradient(135deg,#4b2c82,#15102b);
+  background:linear-gradient(135deg,#f7f7fa,#eaeaf0);
 }
 
 .card{
@@ -80,7 +91,6 @@ h1{
   border-radius:var(--r-md);
   border:1px solid var(--line);
   background:var(--card);
-  backdrop-filter:blur(10px);
   font-size:16px;
   color:var(--ink);
 }
@@ -121,7 +131,6 @@ h1{
   align-items:center;
   justify-content:center;
   text-align:center;
-  backdrop-filter:blur(10px);
 }
 
 .pill:hover{


### PR DESCRIPTION
## Summary
- detect device theme and support light/dark color schemes
- reduce transparency and remove glass blur for sturdier look
- smooth out background gradient for subtle appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab814e7d30832698d09b3d5dff33de