### PR TITLE
fix: add dark mode background gradient

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,8 @@
   --accent:#16A34A; --brand:#FF7A00; --action:#7C3AED;
   --btn-border:rgba(0,0,0,0.1); --segment:#f5f5f5; --bar:#e0e0e0;
 
+  --bg:linear-gradient(135deg,#f7f7fa,#eaeaf0);
+
   --r-xxl:32px; --r-xl:20px; --r-lg:14px; --r-md:12px; --r-pill:9999px;
   --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px;
 
@@ -20,8 +22,8 @@
 
     --shadow-card:0 1px 2px rgba(0,0,0,.25),0 8px 20px rgba(0,0,0,.3);
     --shadow-float:0 1px 1px rgba(0,0,0,.2),0 4px 10px rgba(0,0,0,.3);
+    --bg:linear-gradient(135deg,#2a2348,#000000);
   }
-  body{background:linear-gradient(135deg,#2a2348,#1a162c);}
 }
 .card{
   background:var(--card);
@@ -61,7 +63,7 @@ body{
   align-items:center;
   min-height:100vh;
   color:var(--ink);
-  background:linear-gradient(135deg,#f7f7fa,#eaeaf0);
+  background:var(--bg);
 }
 
 .card{


### PR DESCRIPTION
## Summary
- ensure dark mode uses a purple to black background gradient via CSS variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab826532408326b50e0543868dcd96