### PR TITLE
Add Q shortcut to copy top name

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <div class="card">
+    <div id="q-hint">Press <span id="q-key" class="key">Q</span></div>
     <h1>Random Name Generator</h1>
     <div class="controls">
       <label for="region">Region:</label>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
 const regionSelect = document.getElementById('region');
 const refreshBtn = document.getElementById('refresh');
 const container = document.getElementById('name-container');
+const qKey = document.getElementById('q-key');
 const NUM_PILLS = 9;
 
 sanitizeNameData(nameData);
@@ -74,6 +75,30 @@ function handleCopy(pill) {
     }, 700);
   });
 }
+
+function copyFirstAvailable() {
+  const pill = container.querySelector('.pill:not(.copied)');
+  if (pill) {
+    handleCopy(pill);
+  } else {
+    generateNames();
+  }
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key.toLowerCase() === 'q') {
+    if (e.repeat) return;
+    e.preventDefault();
+    if (qKey) qKey.classList.add('pressed');
+    copyFirstAvailable();
+  }
+});
+
+document.addEventListener('keyup', e => {
+  if (e.key.toLowerCase() === 'q' && qKey) {
+    qKey.classList.remove('pressed');
+  }
+});
 
 refreshBtn.addEventListener('click', generateNames);
 regionSelect.addEventListener('change', generateNames);

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,7 @@ body{
   text-align:center;
   width:90%;
   max-width:600px;
+  position:relative;
 }
 
 h1{
@@ -151,5 +152,35 @@ h1{
   background:var(--line);
   color:var(--muted);
   border-color:var(--line);
+}
+
+#q-hint{
+  position:absolute;
+  top:8px;
+  left:8px;
+  display:flex;
+  align-items:center;
+  gap:4px;
+  font-size:14px;
+  color:var(--muted);
+}
+
+#q-hint .key{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:20px;
+  height:20px;
+  padding:2px 6px;
+  border:1px solid var(--line);
+  border-radius:4px;
+  background:var(--segment);
+  box-shadow:0 2px 0 var(--line);
+  font-weight:600;
+}
+
+#q-hint .key.pressed{
+  box-shadow:0 1px 0 var(--line) inset;
+  transform:translateY(2px);
 }
 


### PR DESCRIPTION
## Summary
- show "Press Q" hint with key graphic on card
- pressing Q copies first unused name or refreshes when all are used
- visual key press feedback for the Q key

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab8c4a2b4c8326831fa5f0e0ff2f91