### PR TITLE
feat: make Q key clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <div class="card">
-    <div id="q-hint">Press <span id="q-key" class="key">Q</span></div>
+    <div id="q-hint">Press <button id="q-key" class="key" type="button">Q</button></div>
     <h1>Random Name Generator</h1>
     <div class="controls">
       <label for="region">Region:</label>

--- a/script.js
+++ b/script.js
@@ -100,6 +100,16 @@ document.addEventListener('keyup', e => {
   }
 });
 
+if (qKey) {
+  qKey.addEventListener('click', () => {
+    copyFirstAvailable();
+  });
+  qKey.addEventListener('mousedown', () => qKey.classList.add('pressed'));
+  ['mouseup', 'mouseleave'].forEach(evt =>
+    qKey.addEventListener(evt, () => qKey.classList.remove('pressed'))
+  );
+}
+
 refreshBtn.addEventListener('click', generateNames);
 regionSelect.addEventListener('change', generateNames);
 // Wait for fonts to load so the pill dimensions are accurate on first render


### PR DESCRIPTION
## Summary
- Make the on-screen Q key a button that triggers copying or generating names
- Handle mouse interactions on the Q button to mirror keyboard behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abb6f28644832688e7bb0e9882f5a4