### PR TITLE
Remove cooldown before copying next name

### DIFF
--- a/script.js
+++ b/script.js
@@ -69,9 +69,9 @@ function handleCopy(pill) {
   const name = pill.dataset.name;
   navigator.clipboard.writeText(name).then(() => {
     pill.textContent = '✓ Copied';
+    pill.classList.add('copied');
     setTimeout(() => {
       pill.textContent = name;
-      pill.classList.add('copied');
     }, 700);
   });
 }


### PR DESCRIPTION
## Summary
- mark copied name pill immediately so pressing "q" rapidly selects next name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abb9ce818883268da21f504ebf910c