### PR TITLE
feat: add q key press animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,6 +85,12 @@ function copyFirstAvailable() {
   }
 }
 
+function animateQKey() {
+  if (!qKey) return;
+  qKey.classList.add('animate');
+  qKey.addEventListener('animationend', () => qKey.classList.remove('animate'), { once: true });
+}
+
 document.addEventListener('keydown', e => {
   if (e.key.toLowerCase() === 'q') {
     if (e.repeat) return;
@@ -97,6 +103,7 @@ document.addEventListener('keydown', e => {
 document.addEventListener('keyup', e => {
   if (e.key.toLowerCase() === 'q' && qKey) {
     qKey.classList.remove('pressed');
+    animateQKey();
   }
 });
 
@@ -106,7 +113,10 @@ if (qKey) {
   });
   qKey.addEventListener('mousedown', () => qKey.classList.add('pressed'));
   ['mouseup', 'mouseleave'].forEach(evt =>
-    qKey.addEventListener(evt, () => qKey.classList.remove('pressed'))
+    qKey.addEventListener(evt, () => {
+      qKey.classList.remove('pressed');
+      animateQKey();
+    })
   );
 }
 

--- a/styles.css
+++ b/styles.css
@@ -191,3 +191,13 @@ h1{
   transform:translateY(2px);
 }
 
+#q-hint .key.animate{
+  animation:q-press 0.2s ease-out;
+}
+
+@keyframes q-press{
+  0%{transform:scale(0.95);}
+  60%{transform:scale(1.05);}
+  100%{transform:scale(1);}
+}
+


### PR DESCRIPTION
## Summary
- animate Q helper key to pop when used
- trigger animation on keyboard and mouse interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abbaab5a34832685f5f0bd605faa27