### PR TITLE
Add snappier Q key and pill copy animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -69,7 +69,8 @@ function handleCopy(pill) {
   const name = pill.dataset.name;
   navigator.clipboard.writeText(name).then(() => {
     pill.textContent = '✓ Copied';
-    pill.classList.add('copied');
+    pill.classList.add('copied', 'copied-anim');
+    pill.addEventListener('animationend', () => pill.classList.remove('copied-anim'), { once: true });
     setTimeout(() => {
       pill.textContent = name;
     }, 700);

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,8 @@ h1{
   align-items:center;
   justify-content:center;
   text-align:center;
+  position:relative;
+  overflow:visible;
 }
 
 .pill:hover{
@@ -152,6 +154,24 @@ h1{
   background:var(--line);
   color:var(--muted);
   border-color:var(--line);
+}
+
+.pill.copied-anim::after{
+  content:"";
+  position:absolute;
+  top:-2px;
+  left:-2px;
+  right:-2px;
+  bottom:-2px;
+  border:2px solid var(--action);
+  border-radius:inherit;
+  pointer-events:none;
+  animation:pill-ring .4s ease-out forwards;
+}
+
+@keyframes pill-ring{
+  from{opacity:1; transform:scale(1);}
+  to{opacity:0; transform:scale(1.3);}
 }
 
 #q-hint{
@@ -192,12 +212,12 @@ h1{
 }
 
 #q-hint .key.animate{
-  animation:q-press 0.2s ease-out;
+  animation:q-press .1s cubic-bezier(.4,0,.6,1);
 }
 
 @keyframes q-press{
-  0%{transform:scale(0.95);}
-  60%{transform:scale(1.05);}
+  0%{transform:scale(.9);}
+  50%{transform:scale(1.1);}
   100%{transform:scale(1);}
 }
 


### PR DESCRIPTION
## Summary
- Speed up Q key animation with quicker timing and easing
- Show an expanding ring animation around name pills when copied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abbbf28d648326a8dd7036913f6fc9