### PR TITLE
Add subtle purple gradient and soften copy animation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@
   --accent:#16A34A; --brand:#FF7A00; --action:#7C3AED;
   --btn-border:rgba(0,0,0,0.1); --segment:#f5f5f5; --bar:#e0e0e0;
 
-  --bg:linear-gradient(135deg,#f7f7fa,#eaeaf0);
+  --bg:linear-gradient(135deg,#faf9ff,#ece9ff);
 
   --r-xxl:32px; --r-xl:20px; --r-lg:14px; --r-md:12px; --r-pill:9999px;
   --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px;
@@ -163,15 +163,15 @@ h1{
   left:-2px;
   right:-2px;
   bottom:-2px;
-  border:2px solid var(--action);
+  border:2px solid rgba(124,58,237,0.5);
   border-radius:inherit;
   pointer-events:none;
-  animation:pill-ring .4s ease-out forwards;
+  animation:pill-ring .3s ease-out forwards;
 }
 
 @keyframes pill-ring{
-  from{opacity:1; transform:scale(1);}
-  to{opacity:0; transform:scale(1.3);}
+  from{opacity:0.6; transform:scale(1);}
+  to{opacity:0; transform:scale(1.15);}
 }
 
 #q-hint{


### PR DESCRIPTION
## Summary
- Soften copy feedback ring and shorten its animation
- Use a light purple-tinted gradient for the light theme background

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc911574c832684188a43979b62ee