### PR TITLE
feat: add tabbed kayak search

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,22 +11,38 @@
 </head>
 <body>
   <div class="card">
-    <div id="q-hint">Press <button id="q-key" class="key" type="button">Q</button></div>
-    <h1>Random Name Generator</h1>
-    <div class="controls">
-      <label for="region">Region:</label>
-      <select id="region">
-        <option value="northAmerica">North America</option>
-        <option value="europe">Europe</option>
-        <option value="india">India</option>
-        <option value="africa">Africa</option>
-        <option value="asia">Asia</option>
-      </select>
-      <button id="refresh" class="btn-primary" title="Refresh names">🔄</button>
-      <button id="kayak" class="btn-primary" title="Kayak flex search">🛶</button>
+    <div class="tabs">
+      <button class="tab active" data-tab="names">Random Names</button>
+      <button class="tab" data-tab="kayak">Kayak Flex Search</button>
     </div>
-    <div id="name-container"></div>
-    <div id="kayak-results"></div>
+    <div id="tab-names" class="tab-content active">
+      <div id="q-hint">Press <button id="q-key" class="key" type="button">Q</button></div>
+      <h1>Random Name Generator</h1>
+      <div class="controls">
+        <label for="region">Region:</label>
+        <select id="region">
+          <option value="northAmerica">North America</option>
+          <option value="europe">Europe</option>
+          <option value="india">India</option>
+          <option value="africa">Africa</option>
+          <option value="asia">Asia</option>
+        </select>
+        <button id="refresh" class="btn-primary" title="Refresh names">🔄</button>
+      </div>
+      <div id="name-container"></div>
+    </div>
+    <div id="tab-kayak" class="tab-content">
+      <h1>Kayak Flex Search</h1>
+      <form id="kayak-form" class="kayak-form">
+        <label for="kayak-url">Kayak multi-city URL:</label>
+        <input type="url" id="kayak-url" required>
+        <label for="kayak-flex">Flexibility (± days):</label>
+        <input type="number" id="kayak-flex" min="1" max="7" value="1" required>
+        <button type="submit" class="btn-primary">Generate</button>
+        <p id="kayak-error" class="error" aria-live="polite"></p>
+      </form>
+      <div id="kayak-results"></div>
+    </div>
   </div>
   <script src="names.js"></script>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -3,8 +3,13 @@ const regionSelect = document.getElementById('region');
 const refreshBtn = document.getElementById('refresh');
 const container = document.getElementById('name-container');
 const qKey = document.getElementById('q-key');
-const kayakBtn = document.getElementById('kayak');
 const kayakResults = document.getElementById('kayak-results');
+const kayakForm = document.getElementById('kayak-form');
+const kayakUrl = document.getElementById('kayak-url');
+const kayakFlexInput = document.getElementById('kayak-flex');
+const kayakError = document.getElementById('kayak-error');
+const tabButtons = document.querySelectorAll('.tab');
+const tabContents = document.querySelectorAll('.tab-content');
 const NUM_PILLS = 9;
 
 sanitizeNameData(nameData);
@@ -123,20 +128,30 @@ if (qKey) {
   );
 }
 
-if (kayakBtn) {
-  kayakBtn.addEventListener('click', () => {
-    const url = prompt('Paste Kayak multi-city URL:');
-    if (!url) return;
-    const flex = parseInt(prompt('Flexibility (±1-7 days):'), 10);
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    tabButtons.forEach(b => b.classList.remove('active'));
+    tabContents.forEach(c => c.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById(`tab-${btn.dataset.tab}`).classList.add('active');
+  });
+});
+
+if (kayakForm) {
+  kayakForm.addEventListener('submit', e => {
+    e.preventDefault();
+    kayakError.textContent = '';
+    const url = kayakUrl.value.trim();
+    const flex = parseInt(kayakFlexInput.value, 10);
     if (isNaN(flex) || flex < 1 || flex > 7) {
-      alert('Invalid flexibility');
+      kayakError.textContent = 'Flex must be between 1 and 7.';
       return;
     }
     try {
       const data = kayakFlex(url, flex);
       renderKayak(data);
     } catch (err) {
-      alert('Could not parse URL');
+      kayakError.textContent = 'Could not parse URL.';
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -227,3 +227,49 @@ h1{
 #kayak-results a{text-decoration:none;color:var(--action);}
 #kayak-results a:hover{text-decoration:underline;}
 
+.tabs{
+  display:flex;
+  justify-content:center;
+  margin-bottom:var(--space-4);
+  gap:var(--space-3);
+  border-bottom:1px solid var(--line);
+}
+
+.tab{
+  background:none;
+  border:none;
+  padding:var(--space-3) var(--space-4);
+  cursor:pointer;
+  font-size:16px;
+  color:var(--muted);
+}
+
+.tab.active{
+  color:var(--ink);
+  border-bottom:2px solid var(--ink);
+  font-weight:600;
+}
+
+.tab-content{display:none;}
+.tab-content.active{display:block;}
+
+.kayak-form{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:var(--space-3);
+  margin-bottom:var(--space-4);
+}
+
+.kayak-form input{
+  padding:10px 14px;
+  border-radius:var(--r-md);
+  border:1px solid var(--line);
+  background:var(--card);
+  color:var(--ink);
+  width:100%;
+  max-width:400px;
+}
+
+.error{color:var(--brand);}
+


### PR DESCRIPTION
## Summary
- add two-tab layout toggling between random names and kayak flex search
- provide inline kayak URL & flexibility form to generate date combinations
- style tabs and kayak form for seamless in-card experience

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae114a447c8326a94a5f6624b6da28