### PR TITLE
Add dropdown for flex search and improve date table

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,15 @@
         <label for="kayak-url">Kayak multi-city URL:</label>
         <input type="url" id="kayak-url" required>
         <label for="kayak-flex">Flexibility (± days):</label>
-        <input type="number" id="kayak-flex" min="1" max="7" value="1" required>
+        <select id="kayak-flex" required>
+          <option value="1">±1</option>
+          <option value="2">±2</option>
+          <option value="3">±3</option>
+          <option value="4">±4</option>
+          <option value="5">±5</option>
+          <option value="6">±6</option>
+          <option value="7">±7</option>
+        </select>
         <button type="submit" class="btn-primary">Generate</button>
         <p id="kayak-error" class="error" aria-live="polite"></p>
       </form>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ const qKey = document.getElementById('q-key');
 const kayakResults = document.getElementById('kayak-results');
 const kayakForm = document.getElementById('kayak-form');
 const kayakUrl = document.getElementById('kayak-url');
-const kayakFlexInput = document.getElementById('kayak-flex');
+const kayakFlexSelect = document.getElementById('kayak-flex');
 const kayakError = document.getElementById('kayak-error');
 const tabButtons = document.querySelectorAll('.tab');
 const tabContents = document.querySelectorAll('.tab-content');
@@ -142,7 +142,7 @@ if (kayakForm) {
     e.preventDefault();
     kayakError.textContent = '';
     const url = kayakUrl.value.trim();
-    const flex = parseInt(kayakFlexInput.value, 10);
+    const flex = parseInt(kayakFlexSelect.value, 10);
     if (isNaN(flex) || flex < 1 || flex > 7) {
       kayakError.textContent = 'Flex must be between 1 and 7.';
       return;
@@ -169,7 +169,7 @@ function dateRange(dateStr, flex) {
     d.setDate(d.getDate() + i);
     arr.push(d.toISOString().slice(0, 10));
   }
-  return arr;
+  return [...new Set(arr)];
 }
 
 function replaceDates(baseUrl, newDates) {
@@ -208,19 +208,36 @@ function renderKayak(data) {
   if (dates.length === 2) {
     const [outOpts, retOpts] = options;
     const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    headRow.appendChild(document.createElement('th'));
+    retOpts.forEach(d2 => {
+      const th = document.createElement('th');
+      th.textContent = formatDM(d2);
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
     outOpts.forEach(d1 => {
       const tr = document.createElement('tr');
+      const rowHead = document.createElement('th');
+      rowHead.textContent = formatDM(d1);
+      tr.appendChild(rowHead);
       retOpts.forEach(d2 => {
         const td = document.createElement('td');
         const a = document.createElement('a');
         a.href = replaceDates(url, [d1, d2]);
         a.target = '_blank';
-        a.textContent = `${formatDM(d1)}-${formatDM(d2)}`;
+        a.textContent = '•';
+        a.setAttribute('aria-label', `${formatDM(d1)} - ${formatDM(d2)}`);
+        a.title = `${formatDM(d1)} - ${formatDM(d2)}`;
         td.appendChild(a);
         tr.appendChild(td);
       });
-      table.appendChild(tr);
+      tbody.appendChild(tr);
     });
+    table.appendChild(tbody);
     kayakResults.appendChild(table);
   } else {
     const combos = generateCombinations(options);

--- a/styles.css
+++ b/styles.css
@@ -223,7 +223,7 @@ h1{
 
 #kayak-results{margin-top:var(--space-4);}
 #kayak-results table{border-collapse:collapse;margin:0 auto;}
-#kayak-results td{border:1px solid var(--line);padding:4px 8px;}
+#kayak-results td,#kayak-results th{border:1px solid var(--line);padding:4px 8px;}
 #kayak-results a{text-decoration:none;color:var(--action);}
 #kayak-results a:hover{text-decoration:underline;}
 


### PR DESCRIPTION
## Summary
- Replace numeric flexibility input with dropdown selection
- Deduplicate date ranges and render Kayak results with row/column headers for unique dates
- Style table headers to match cells

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f35b608832695b0ee85f215de0c