### PR TITLE
Highlight hovered Kayak table row and column

### DIFF
--- a/script.js
+++ b/script.js
@@ -199,6 +199,24 @@ function kayakFlex(url, flex) {
   return { url, dates, options };
 }
 
+function addHoverHighlights(table) {
+  const cells = table.querySelectorAll('tbody td');
+  cells.forEach(td => {
+    td.addEventListener('mouseenter', () => {
+      const col = td.cellIndex;
+      table.querySelectorAll('tr').forEach(row => {
+        if (row.contains(td)) row.classList.add('hover-row');
+        const cell = row.children[col];
+        if (cell) cell.classList.add('hover-col');
+      });
+    });
+    td.addEventListener('mouseleave', () => {
+      table.querySelectorAll('.hover-row').forEach(r => r.classList.remove('hover-row'));
+      table.querySelectorAll('.hover-col').forEach(c => c.classList.remove('hover-col'));
+    });
+  });
+}
+
 function renderKayak(data) {
   kayakResults.innerHTML = '';
   const { url, dates, options } = data;
@@ -239,6 +257,7 @@ function renderKayak(data) {
     });
     table.appendChild(tbody);
     kayakResults.appendChild(table);
+    addHoverHighlights(table);
   } else {
     const combos = generateCombinations(options);
     const list = document.createElement('ul');

--- a/styles.css
+++ b/styles.css
@@ -236,9 +236,25 @@ h1{
 
 #kayak-results{margin-top:var(--space-4);}
 #kayak-results table{border-collapse:collapse;margin:0 auto;}
-#kayak-results td,#kayak-results th{border:1px solid var(--line);padding:4px 8px;}
-#kayak-results a{text-decoration:none;color:var(--action);}
-#kayak-results a:hover{text-decoration:underline;}
+#kayak-results th,#kayak-results td{border:1px solid var(--line);}
+#kayak-results th{padding:4px 8px;}
+#kayak-results td{padding:0;}
+#kayak-results td a{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:100%;
+  height:100%;
+  padding:8px;
+  font-size:20px;
+  text-decoration:none;
+  color:var(--action);
+}
+#kayak-results td a:hover{text-decoration:underline;}
+#kayak-results tr.hover-row th,
+#kayak-results tr.hover-row td,
+#kayak-results th.hover-col,
+#kayak-results td.hover-col{background:rgba(99,102,241,0.15);}
 
 .tabs{
   display:flex;


### PR DESCRIPTION
## Summary
- Highlight corresponding row and column when hovering Kayak date cells
- Expand table cell link area for easier clicks

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af208d3a348326a417107335df4ecf