### PR TITLE
Keep TSA pills beside their base names

### DIFF
--- a/script.js
+++ b/script.js
@@ -154,7 +154,7 @@ function renderNames(showTsa = tsaToggle ? tsaToggle.checked : false) {
   const tsaPills = [];
   currentPeople.forEach(person => {
     const row = document.createElement('div');
-    row.className = showTsa ? 'pill-row' : 'pill-row single';
+    row.className = showTsa ? 'pill-row double' : 'pill-row single';
     const basePill = createPill(person.baseName);
     row.appendChild(basePill);
     basePills.push(basePill);
@@ -165,8 +165,19 @@ function renderNames(showTsa = tsaToggle ? tsaToggle.checked : false) {
     }
     container.appendChild(row);
   });
-  equalizePillSizes(basePills);
-  equalizePillSizes(tsaPills);
+  if (showTsa) {
+    equalizePillHeights([...basePills, ...tsaPills]);
+  } else {
+    equalizePillSizes(basePills);
+  }
+}
+
+function equalizePillHeights(pills) {
+  if (!pills.length) return;
+  const maxHeight = Math.max(...pills.map(p => p.offsetHeight));
+  pills.forEach(p => {
+    p.style.height = `${maxHeight}px`;
+  });
 }
 
 function generateNames() {

--- a/styles.css
+++ b/styles.css
@@ -159,15 +159,18 @@ h1{
 }
 
 .pill-row{
-  display:flex;
+  display:grid;
   gap:var(--space-3);
   align-items:center;
   justify-content:center;
-  flex-wrap:wrap;
+}
+
+.pill-row.double{
+  grid-template-columns:repeat(2, auto);
 }
 
 .pill-row.single{
-  justify-content:center;
+  grid-template-columns:auto;
 }
 
 .pill{


### PR DESCRIPTION
## Summary
- switch the name rows to use a grid layout so TSA entries stay next to the base names
- adjust the rendering script to add a dedicated class when TSA data is shown and equalize pill heights without forcing widths

## Testing
- Manual QA - toggled the TSA format view in the browser

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164485b0c48326bee913f6ea4d1648)